### PR TITLE
fix: guard fluid mousemove while canvas is hidden (wallpaper mode)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1317,6 +1317,7 @@ void main() {
 			const windows = ua.userAgentData ? ua.userAgentData.platform === "Windows" : navigator.userAgent.includes("Windows");
 			const onMouseMove = (event) => {
 				const rect = canvas.getBoundingClientRect();
+				if (rect.width <= 0 || rect.height <= 0) return;
 				pointer.x = (event.clientX - rect.left) / rect.width;
 				pointer.y = 1 - (event.clientY - rect.top) / rect.height;
 			};
@@ -1332,6 +1333,7 @@ void main() {
 				const ratio = Math.min(window.devicePixelRatio || 1, 1.5);
 				const nextWidth = Math.round(canvas.clientWidth * ratio);
 				const nextHeight = Math.round(canvas.clientHeight * ratio);
+				if (nextWidth <= 0 || nextHeight <= 0) return;
 				if (nextWidth !== width || nextHeight !== height) {
 					width = nextWidth;
 					height = nextHeight;

--- a/src/client/fluid-shader.ts
+++ b/src/client/fluid-shader.ts
@@ -364,6 +364,10 @@ export function attachFluidShader(canvas: HTMLCanvasElement, params: FluidParams
     : navigator.userAgent.includes('Windows')
   const onMouseMove = (event: MouseEvent): void => {
     const rect = canvas.getBoundingClientRect()
+    // Guard against the wallpaper mode hiding the canvas (display: none → a
+    // 0×0 rect): feeding NaN/Infinity pointer coordinates into the flow
+    // shader poisons the simulation permanently (NaN never decays).
+    if (rect.width <= 0 || rect.height <= 0) return
     pointer.x = (event.clientX - rect.left) / rect.width
     pointer.y = 1 - (event.clientY - rect.top) / rect.height
   }
@@ -382,6 +386,8 @@ export function attachFluidShader(canvas: HTMLCanvasElement, params: FluidParams
     const ratio = Math.min(window.devicePixelRatio || 1, 1.5)
     const nextWidth = Math.round(canvas.clientWidth * ratio)
     const nextHeight = Math.round(canvas.clientHeight * ratio)
+    // Hidden canvas (wallpaper mode): skip GL work entirely this frame.
+    if (nextWidth <= 0 || nextHeight <= 0) return
     if (nextWidth !== width || nextHeight !== height) {
       width = nextWidth
       height = nextHeight


### PR DESCRIPTION
## 问题 / Bug

背景切到「壁纸」之后，`aqua.module.css` 用 `display: none` 隐藏流体画布，但 `fluid-shader.ts` 里挂在 `window` 上的 `mousemove` 监听仍在运行：

```ts
const rect = canvas.getBoundingClientRect()          // display:none → 0×0
pointer.x = (event.clientX - rect.left) / rect.width // 除以 0 → NaN
```

NaN 进入 flow shader 的 ping-pong 纹理后永不衰减（`NaN × decay = NaN`），整个流体模拟被永久污染。切回「流体」之后水不再流动、也不再跟随鼠标，只能刷新页面（重新挂载）恢复。

## 复现 / Repro

1. 打开流体背景，确认水跟手正常
2. 设置 → 外观 → 背景切换为「壁纸」
3. 在页面上移动鼠标
4. 切回「流体」→ 水流/跟手效果消失

## 修复 / Fix

- `onMouseMove` 在画布 rect 为 0 时跳过指针更新，NaN 不再进入模拟
- 渲染循环在画布零尺寸时整帧跳过（顺带省 GPU）

改动两处：`src/client/fluid-shader.ts`（源码）与 `lib/client.js`（已发布 bundle，与 src 改动逐行一致；本环境没有 tsdown 构建链，可直接用 src diff 重建 bundle）。

## 验证 / Verification

无头 Chromium 完整复现「隐藏画布 → 移动鼠标 → 恢复画布」流程，修复后流体正常渲染、持续动画，控制台无报错。
